### PR TITLE
Refactor & improve Keystatic content definitions

### DIFF
--- a/src/content/singles/homepage/index.yaml
+++ b/src/content/singles/homepage/index.yaml
@@ -22,83 +22,84 @@ heroHeader:
       href: /request-demo
       newTab: false
       variant: secondary
-content:
-  - discriminant: brandsBlock
-    value:
-      header:
-        title: Powering 30,000+ discovery experiences across categories
-  - discriminant: featuresBlock
-    value:
-      header:
-        tagline: End-to-end
-        title: Trieve Coordinates, You Scale
-        leadText: >-
-          Billion-scale search, discovery, and RAG experiences within the same
-          API
-      items:
-        - title: Semantic Vector Search
-          description: >-
-            For when you need more than just full-text search. Trieve supports
-            semantic vector search out of the box.
-        - title: Stock and Custom Embedding models
-          description: >-
-            Our modular infrastructure offers several models and bring your own
-            embedding model.
-        - title: Merchandising & Relevance tuning
-          description: >-
-            Tune and boost search results to hit your KPIs via the API or
-            no-code dashboard.
-        - title: BM25 & SPLADE Full-Text Search
-          description: >-
-            Choose between the leading state-of-the-art retrieval models for
-            full-text search.
-        - title: Hybrid Search
-          description: >-
-            Get the best of both worlds. Trieve supports hybrid search,
-            combining full-text search and semantic vector search with
-            cross-encoder re-ranker models.
-        - title: Sub-sentence Highlighting
-          description: >-
-            Search results can get long. Sub-sentence highlights show users
-            exactly what they are looking for, quick.
-  - discriminant: imageAndTextBlock
-    value:
-      header:
-        tagline: Build Fast and Don't Break Things
-        title: Manage ingestion, embeddings and analytics with ease
-      items:
-        - image: /src/assets/images/blocks/content/2/value/items/0/image.png
-          title: Built on the best foundations
-          description: >-
-            We help companies build unfair competitive advantages through their
-            search, discovery, and RAG experiences
-          items:
-            - title: Private Open-Source Models
-              description: >-
-                We use open source embedding models and LLMs running in our own
-                servers. Data is never leaked.
-            - title: Batteries Included
-              description: >-
-                Our API surface covers chunking, ingestion, search,
-                recommendations, RAG, and even a little front-end.
-            - title: Self-Hostable
-              description: >-
-                Sensitive data? Need maximum performance? Host Trieve yourself
-                with terraform templates and no external dependencies.
-        - image: /src/assets/images/blocks/content/2/value/items/1/image.png
-          title: Set up industry-leading search in 30 minutes
-          items:
-            - title: 'Step 1: Add Existing Data'
-              description: >-
-                Upload individual chunks or entire documents that get chunked by
-                our algorithms via our API or no-code dashboard.
-            - title: 'Step 2: Integrate our API'
-              description: >-
-                Add calls to our API on your create and update routes to keep
-                your data current.
-            - title: 'Step 3: Search, Recommend, or Generate'
-              description: >-
-                Test and tune search, recommendations, and chat quality with our
-                search playground, then integrate the API calls into your
-                product.
-            - title: Ready!
+contentBlocks:
+  content:
+    - discriminant: brandsBlock
+      value:
+        header:
+          title: Powering 30,000+ discovery experiences across categories
+    - discriminant: featuresBlock
+      value:
+        header:
+          tagline: End-to-end
+          title: Trieve Coordinates, You Scale
+          leadText: >-
+            Billion-scale search, discovery, and RAG experiences within the same
+            API
+        items:
+          - title: Semantic Vector Search
+            description: >-
+              For when you need more than just full-text search. Trieve supports
+              semantic vector search out of the box.
+          - title: Stock and Custom Embedding models
+            description: >-
+              Our modular infrastructure offers several models and bring your own
+              embedding model.
+          - title: Merchandising & Relevance tuning
+            description: >-
+              Tune and boost search results to hit your KPIs via the API or
+              no-code dashboard.
+          - title: BM25 & SPLADE Full-Text Search
+            description: >-
+              Choose between the leading state-of-the-art retrieval models for
+              full-text search.
+          - title: Hybrid Search
+            description: >-
+              Get the best of both worlds. Trieve supports hybrid search,
+              combining full-text search and semantic vector search with
+              cross-encoder re-ranker models.
+          - title: Sub-sentence Highlighting
+            description: >-
+              Search results can get long. Sub-sentence highlights show users
+              exactly what they are looking for, quick.
+    - discriminant: imageAndTextBlock
+      value:
+        header:
+          tagline: Build Fast and Don't Break Things
+          title: Manage ingestion, embeddings and analytics with ease
+        items:
+          - image: /src/assets/images/blocks/content/2/value/items/0/image.png
+            title: Built on the best foundations
+            description: >-
+              We help companies build unfair competitive advantages through their
+              search, discovery, and RAG experiences
+            items:
+              - title: Private Open-Source Models
+                description: >-
+                  We use open source embedding models and LLMs running in our own
+                  servers. Data is never leaked.
+              - title: Batteries Included
+                description: >-
+                  Our API surface covers chunking, ingestion, search,
+                  recommendations, RAG, and even a little front-end.
+              - title: Self-Hostable
+                description: >-
+                  Sensitive data? Need maximum performance? Host Trieve yourself
+                  with terraform templates and no external dependencies.
+          - image: /src/assets/images/blocks/content/2/value/items/1/image.png
+            title: Set up industry-leading search in 30 minutes
+            items:
+              - title: "Step 1: Add Existing Data"
+                description: >-
+                  Upload individual chunks or entire documents that get chunked by
+                  our algorithms via our API or no-code dashboard.
+              - title: "Step 2: Integrate our API"
+                description: >-
+                  Add calls to our API on your create and update routes to keep
+                  your data current.
+              - title: "Step 3: Search, Recommend, or Generate"
+                description: >-
+                  Test and tune search, recommendations, and chat quality with our
+                  search playground, then integrate the API calls into your
+                  product.
+              - title: Ready!

--- a/src/lib/keystatic/collections/pages.ts
+++ b/src/lib/keystatic/collections/pages.ts
@@ -14,11 +14,15 @@ export const pages = collection({
       name: {
         label: "Page title",
         description: "The name of the page (may be used in navigation, etc.)",
+        validation: {
+          isRequired: true,
+        },
       },
       // Optional slug label overrides
       slug: {
         label: "SEO-friendly slug",
-        description: "The unique, URL-friendly slug for the page",
+        description:
+          "The unique, URL-friendly slug for the page (don't include slashes in front)",
       },
     }),
     metaData,

--- a/src/lib/keystatic/shared/base.ts
+++ b/src/lib/keystatic/shared/base.ts
@@ -1,0 +1,19 @@
+import { fields } from "@keystatic/core";
+
+export const baseHeaderFields = {
+  tagline: fields.text({
+    label: "Tagline",
+    description: "Small tagline text, appears above the title",
+  }),
+  title: fields.text({
+    label: "Title",
+    description: "The main title text for the section",
+    validation: {
+      isRequired: true,
+    },
+  }),
+  leadText: fields.text({
+    label: "Lead Text",
+    description: "Lead text for the section (appears below the title)",
+  }),
+};

--- a/src/lib/keystatic/shared/content-blocks.ts
+++ b/src/lib/keystatic/shared/content-blocks.ts
@@ -1,10 +1,5 @@
 import { fields } from "@keystatic/core";
-
-const baseHeaderFields = {
-  tagline: fields.text({ label: "Tagline" }),
-  title: fields.text({ label: "Title" }),
-  leadText: fields.text({ label: "Lead Text" }),
-};
+import { baseHeaderFields } from "./base";
 
 // Generic section header block
 export const headerBlock = {
@@ -107,20 +102,7 @@ export const brandsBlock = {
   }),
 };
 
-// Shared content blocks (@deprecated)
-export const content = fields.blocks(
-  {
-    headerBlock: headerBlock,
-    featuresBlock: featuresBlock,
-    imageAndTextBlock: imageAndTextBlock,
-    brandsBlock: brandsBlock,
-  },
-  {
-    label: "Content Sections",
-    description: "The dynamic content blocks to display on the homepage",
-  }
-);
-
+// Dynamic section of content blocks
 export const contentBlocks = fields.object(
   {
     content: fields.blocks(

--- a/src/lib/keystatic/shared/hero-header.ts
+++ b/src/lib/keystatic/shared/hero-header.ts
@@ -1,15 +1,29 @@
 import { fields } from "@keystatic/core";
+import { baseHeaderFields } from "./base";
 
 export const heroHeader = fields.object(
   {
-    tagline: fields.text({ label: "Hero tagline" }),
-    title: fields.text({ label: "Hero title" }),
-    leadText: fields.text({ label: "Hero lead text" }),
+    ...baseHeaderFields,
     actions: fields.array(
       fields.object({
-        label: fields.text({ label: "Action label" }),
-        href: fields.text({ label: "Action href" }),
-        newTab: fields.checkbox({ label: "Open in new tab" }),
+        label: fields.text({
+          label: "Action label",
+          description: "The text to display on the action button",
+          validation: {
+            isRequired: true,
+          },
+        }),
+        href: fields.text({
+          label: "Action href",
+          description: "The URL to navigate to when the action is clicked",
+          validation: {
+            isRequired: true,
+          },
+        }),
+        newTab: fields.checkbox({
+          label: "Open in new tab",
+          description: "Whether to open the link in a new tab",
+        }),
         variant: fields.select({
           label: "Button variant",
           description: "The style variant of the button",

--- a/src/lib/keystatic/shared/metadata.ts
+++ b/src/lib/keystatic/shared/metadata.ts
@@ -2,8 +2,16 @@ import { fields } from "@keystatic/core";
 
 export const metaData = fields.object(
   {
-    title: fields.text({ label: "Meta title" }),
-    description: fields.text({ label: "Meta description", multiline: true }),
+    title: fields.text({
+      label: "Meta title",
+      description: "Title for the page (leave empty for default)",
+    }),
+    description: fields.text({
+      label: "Meta description",
+      multiline: true,
+      description:
+        "Short meta description for the page, (leave empty for default)",
+    }),
   },
   {
     label: "SEO Metadata",

--- a/src/lib/keystatic/shared/page-header.ts
+++ b/src/lib/keystatic/shared/page-header.ts
@@ -1,10 +1,9 @@
 import { fields } from "@keystatic/core";
+import { baseHeaderFields } from "./base";
 
 export const pageHeader = fields.object(
   {
-    tagline: fields.text({ label: "Tagline" }),
-    title: fields.text({ label: "Title" }),
-    leadText: fields.text({ label: "Lead Text" }),
+    ...baseHeaderFields,
   },
   {
     label: "Page Header",

--- a/src/lib/keystatic/singletons/homepage.ts
+++ b/src/lib/keystatic/singletons/homepage.ts
@@ -2,7 +2,7 @@ import { singleton } from "@keystatic/core";
 
 import { metaData } from "../shared/metadata";
 import { heroHeader } from "../shared/hero-header";
-import { content } from "../shared/content-blocks";
+import { contentBlocks } from "../shared/content-blocks";
 
 export const homepage = singleton({
   label: "Homepage",
@@ -10,6 +10,6 @@ export const homepage = singleton({
   schema: {
     metaData,
     heroHeader,
-    content,
+    contentBlocks,
   },
 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,12 +13,12 @@ const homepageContent = await keystatic.singletons.homepage.read();
 invariant(homepageContent, "No homepage content found");
 
 const heroHeader = homepageContent.heroHeader;
-const pageContent = homepageContent.content;
+const pageContent = homepageContent.contentBlocks;
 ---
 
 <Layout>
   <HeroHeader {...heroHeader} />
-  <PageContent content={pageContent} />
+  <PageContent content={pageContent.content} />
 
   {/* Append a call to action section for the homepage */}
   <CallToAction />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
-@source "../components/"
+@source "../components/";
 
 @theme {
   --font-serif:


### PR DESCRIPTION
Improve Keystatic contebt type definitions for better reusability:

- Reduce duplication by using shared schema of the header fields
- Add field validations & descriptions to some of the fields
- Reuse the same content block structure between homepage & content pages
- Updated homepage content & homepage template to match changes

Also:
- Minor fix for typo related to Tailwind CSS setup

At this stage, homepage content is really no different than any other page. I wonder if it even make sense to keep it as separate template (singleton page type) or just keep it as regular content like all other page type?