### PR TITLE
Add collection for legal pages

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -2,6 +2,7 @@ import { config } from "@keystatic/core";
 
 import { articles } from "@lib/keystatic/collections/articles";
 import { authors } from "@lib/keystatic/collections/authors";
+import { legalPages } from "@lib/keystatic/collections/legal-pages";
 import { pages } from "@lib/keystatic/collections/pages";
 import { homepage } from "@lib/keystatic/singletons/homepage";
 import { pricing } from "@lib/keystatic/singletons/pricing";
@@ -14,6 +15,7 @@ export default config({
     articles,
     authors,
     pages,
+    legalPages,
   },
   singletons: {
     homepage,

--- a/src/components/shared/MarkdocRenderer.astro
+++ b/src/components/shared/MarkdocRenderer.astro
@@ -1,0 +1,24 @@
+---
+import Markdoc, { type Node } from "@markdoc/markdoc";
+
+interface Props {
+  contentFn: () => Promise<{
+    node: Node;
+  }>;
+}
+
+const { contentFn } = Astro.props;
+
+const content = await contentFn();
+
+const errors = Markdoc.validate(content.node);
+
+if (errors.length) {
+  throw new Error(errors.join("\n"));
+}
+
+const transformed = Markdoc.transform(content.node);
+const html = Markdoc.renderers.html(transformed);
+---
+
+<div set:html={html} />

--- a/src/content/legal/privacy-policy/index.mdoc
+++ b/src/content/legal/privacy-policy/index.mdoc
@@ -1,0 +1,127 @@
+---
+title: Privacy Policy
+metaData: {}
+---
+Devflow, Inc. (“Devflow,” “we,” “us,” or “our”) provides a SaaS-based machine learning-powered text search platform (the “Services”). This Privacy Policy describes how we handle personal information that we collect about our customers, including when they use our Services or visit our website, https://trieve.ai/.
+
+We treat all personal information covered by this Privacy Policy as pertaining to individuals acting as business representatives, and not in their individual or household capacity. This Privacy Policy does not apply to our handling of personal information that we process on behalf of our customers as a service provider.
+
+## Personal Information We Collect
+
+**Information you provide to us may include:**
+
+**Account information and contact details**,&nbsp;such as your company’s name, your first and last name, username and password, email address, mailing address, and phone number.
+
+**Payment information**, including your payment account details, which we may obtain from your financial institution, when you choose to connect your account to the Services.
+
+**Communications**&nbsp;that we exchange with you, including when you contact us with questions, feedback, or otherwise.
+
+**Marketing data**, such as your preferences for receiving our marketing communications, and details about your engagement with them.
+
+**Other data**&nbsp;not specifically listed here, which we will use as described in this Privacy Policy or as otherwise disclosed at the time of collection.
+
+**Third party sources**.&nbsp;We may combine personal information we receive from you with personal information we obtain from other sources, such as:
+
+- **Third parties**, such as our business partners and others.
+- **Public sources**, such as social media platforms.
+
+**Automatic data collection**.&nbsp;We, our service providers, and our advertising partners may automatically log information about you, your computer or mobile device, and your interaction over time with our website and the Services (in your capacity as our customer’s authorized user), our communications and other online services, such as:
+
+**Device data**,&nbsp;such as your computer’s or mobile device’s operating system type and version, manufacturer and model, browser type, screen resolution, RAM and disk size, CPU usage, device type (e.g., phone, tablet), IP address, unique identifiers (including identifiers used for advertising purposes), language settings, mobile device carrier, radio/network information (e.g., WiFi, LTE, 3G), and general location information such as city, state or geographic area.
+
+**Online activity data**,&nbsp;such as pages or screens you viewed, how long you spent on a page or screen, the website you visited before browsing to the website, navigation paths between pages or screens, information about your activity on a page or screen, access times, and duration of access, and whether you have opened our marketing emails or clicked links within them.
+
+**We use the following tools for automatic data collection:**
+
+**Cookies**, which are text files that websites store on a visitor‘s device to uniquely identify the visitor’s browser or to store information or settings in the browser for the purpose of helping you navigate between pages efficiently, remembering your preferences, enabling functionality, helping us understand user activity and patterns, and facilitating online advertising.
+
+**Local storage technologies**, like HTML5, that provide cookie-equivalent functionality but can store larger amounts of data, including on your device outside of your browser in connection with specific applications.
+
+**Web beacons**, also known as pixel tags or clear GIFs, which are used to demonstrate that a webpage or email was accessed or opened, or that certain content was viewed or clicked.
+
+## How We Use Personal Information
+
+We use your personal information for the following purposes:
+
+**To operate our Services:**
+
+- Provide, operate, maintain, secure and improve our Services.
+- Fulfill a payment or transaction initiated by you.
+- Provide information about our Services.
+- Communicate with you about our Services, including by sending you announcements, updates, security alerts, and support and administrative messages.
+- Understand your needs and interests, and personalize your experience with our Services and our communications.
+- Respond to your requests, questions and feedback.
+
+**Research and development**.&nbsp;As part of these activities, we may create aggregated, de-identified or other anonymous data from personal information we collect. We may use this anonymous data and share it with third parties for our lawful business purposes, including to analyze and improve the Services, and promote our business.
+
+**Marketing and advertising, including for:**
+
+- **Direct marketing**.&nbsp;We may send you direct marketing communications as permitted by law, including, but not limited to, notifying you of special promotions, offers and events via postal mail, email, telephone, text message, and other means. You may opt out of our marketing communications as described in the “Opt out of marketing communications” section below.
+- **Interest-based advertising**.&nbsp;We engage our advertising partners, including third party advertising companies and social media companies, to advertise our Services and other services across the web. We and our advertising partners may use cookies and similar technologies to collect information about your interaction (including the data described in the “Automatic data collection” section above) over time across the web, our communications and other online services, and use that information to serve online ads. You can learn more about your choices for limiting interest-based advertising in the&nbsp;“Online tracking opt out” section below.
+
+**Compliance and protection, including to:**
+
+- Comply with applicable laws, lawful requests, and legal process, such as to respond to subpoenas or requests from government authorities.
+- Protect our, your or others’ rights, privacy, safety or property (including by making and defending legal claims).
+- Audit our internal processes for compliance with legal and contractual requirements and internal policies.
+- Enforce the terms and conditions that govern our website and Services.
+- Prevent, identify, investigate and deter fraudulent, harmful, unauthorized, unethical or illegal activity, including cyberattacks and identity theft.
+
+## How We Share Personal Information
+
+We may share your personal information with:
+
+**Affiliates**.&nbsp;Our corporate parent, subsidiaries, and affiliates, for purposes consistent with this Privacy Policy.
+
+**Service providers**.&nbsp;Companies and individuals that provide services on our behalf or help us operate our Services or our business (such as banking partners, hosting, information technology, customer support, email delivery, and website analytics services).
+
+**Advertising partners**.&nbsp;Third party advertising companies, including for the&nbsp;interest-based advertising purposes described above, that may collect information on our website through cookies and other automated technologies.
+
+**Professional advisors**.&nbsp;Professional advisors, such as lawyers, auditors, bankers and insurers, where necessary in the course of the professional services that they render to us.
+
+**Authorities and others**.&nbsp;Law enforcement, government authorities, and private parties, as we believe in\
+good faith to be necessary or appropriate for the&nbsp;compliance and protection purposes&nbsp;described above.
+
+**Business transferees**.&nbsp;Acquirers and other relevant participants in business transactions (or negotiations for such transactions) involving a corporate divestiture, merger, consolidation, acquisition, reorganization, sale or other disposition of all or any portion of the business or assets of, or equity interests in, Devflow or our affiliates (including, in connection with a bankruptcy or similar proceedings).
+
+## Your Choices
+
+**Opt out of marketing communications**. You may opt out of marketing-related communications by following the opt out or unsubscribe instructions contained in the marketing communications we send you.
+
+**Online tracking opt-out**. There are a number of ways to limit online tracking, which we have summarized below:
+
+- **Blocking cookies in your browser**.&nbsp;Most browsers let you remove or reject cookies, including cookies used for interest-based advertising. To do this, follow the instructions in your browser settings. Many browsers accept cookies by default until you change your settings. For more information about cookies, including how to see what cookies have been set on your device and how to manage and delete them, visit&nbsp;[www.allaboutcookies.org](https://www.allaboutcookies.org/).
+- **Blocking advertising ID use in your mobile settings**.&nbsp;Your mobile device settings may provide functionality to limit use of the advertising ID associated with your mobile device for interest-based advertising purposes.
+- **Using privacy plug-ins or browsers**.&nbsp;You can block our websites from setting cookies used for interest-based ads by using a browser with privacy features, like&nbsp;[Brave](https://brave.com/), or installing browser plugins like&nbsp;[Privacy Badger](https://privacybadger.org/),&nbsp;[Ghostery](https://www.ghostery.com/), or&nbsp;[uBlock Origin](https://ublock.org/), and configuring them to block third party cookies/trackers. You can also opt out of Google Analytics by downloading and installing the browser plug-in available at:&nbsp;[https://tools.google.com/dlpage/gaoptout](https://tools.google.com/dlpage/gaoptout).
+- **Platform opt outs**.&nbsp;The following advertising partners offer opt out features that let you opt out of use of your information for interest-based advertising:
+  - Google:&nbsp;[https://adssettings.google.com/](https://adssettings.google.com/)
+  - Facebook:&nbsp;[www.facebook.com/about/ads](https://www.facebook.com/about/ads)
+  - Twitter:&nbsp;[www.twitter.com/settings/personalization](https://www.twitter.com/settings/personalization)
+- **Advertising industry opt out tools**.&nbsp;You can also use these opt out options to limit use of your information for interest-based advertising by participating companies:
+  - Digital Advertising Alliance for Websites:&nbsp;[optout.aboutads.info](https://optout.aboutads.info/)
+  - Digital Advertising Alliance for Mobile Apps:&nbsp;[https://youradchoices.com/appchoices](https://youradchoices.com/appchoices)
+  - Network Advertising Initiative:&nbsp;[optout.networkadvertising.org](https://optout.networkadvertising.org/)
+
+Note that because these opt out mechanisms are specific to the device or browser on which they are exercised, you will need to opt out on every browser and device that you use.
+
+**Do Not Track**. Some Internet browsers may be configured to send “Do Not Track” signals to the online services that you visit. We currently do not respond to “Do Not Track” or similar signals. To find out more about “Do Not Track,” please visit&nbsp;[https://www.allaboutdnt.com](https://www.allaboutdnt.com/).
+
+## Other Sites and Services
+
+Our Services may contain links to websites and other online services operated by third parties. In addition, our content may be integrated into web pages or other online services that are not associated with us. These links and integrations are not an endorsement of, or representation that we are affiliated with, any third party. We do not control websites or online services operated by third parties, and we are not responsible for their actions.
+
+## Data Security
+
+We employ a number of technical, organizational and physical safeguards designed to protect the personal information we collect. However, no security measures are failsafe and we cannot guarantee the security of your personal information.
+
+## Children
+
+The Services are not intended for use by children under 13 years of age. If we learn that we have collected personal information through our Services from a child under 13 without the consent of the child’s parent or guardian as required by law, we will delete it.
+
+## Changes to This Privacy Policy
+
+We reserve the right to modify this Privacy Policy at any time. If we make material changes to this Privacy Policy, we will notify you by updating the date of this Privacy Policy and posting it on the website.
+
+## How to Contact Us
+
+You can reach us by email at [privacy@trieve.com](mailto:privacy@trieve.com)

--- a/src/content/legal/terms-of-service/index.mdoc
+++ b/src/content/legal/terms-of-service/index.mdoc
@@ -1,0 +1,111 @@
+---
+title: Terms of Service
+metaData: {}
+---
+*Last updated*: January 06, 2023
+
+Please read these terms and conditions carefully before using Our Service.
+
+## Interpretation and Definitions
+
+### Interpretation
+
+The words of which the initial letter is capitalized have meanings defined under the following conditions. The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.
+
+### Definitions
+
+For the purposes of these Terms and Conditions:
+
+- **Affiliate** means an entity that controls, is controlled by or is under common control with a party, where “control” means ownership of 50% or more of the shares, equity interest or other securities entitled to vote for election of directors or other managing authority.
+- **Country** refers to: California, United States
+- **Company** (referred to as either “the Company”, “We”, “Us” or “Our” in this Agreement) refers to Devflow, Inc. DBA Trieve.
+- **Device** means any device that can access the Service such as a computer, a cellphone or a digital tablet.
+- **Service** refers to the Website.
+- **Terms and Conditions** (also referred as “Terms”) mean these Terms and Conditions that form the entire agreement between You and the Company regarding the use of the Service. This Terms and Conditions agreement is a Demo.
+- **Third-party Social Media Service** means any services or content (including data, information, products or services) provided by a third-party that may be displayed, included or made available by the Service.
+- **Website** refers to all trieve.ai subdomains and trieve.ai itself.
+- **You** means the individual accessing or using the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.
+
+## Acknowledgment
+
+These are the Terms and Conditions governing the use of this Service and the agreement that operates between You and the Company. These Terms and Conditions set out the rights and obligations of all users regarding the use of the Service.
+
+Your access to and use of the Service is conditioned on Your acceptance of and compliance with these Terms and Conditions. These Terms and Conditions apply to all visitors, users and others who access or use the Service.
+
+By accessing or using the Service You agree to be bound by these Terms and Conditions. If You disagree with any part of these Terms and Conditions then You may not access the Service.
+
+You represent that you are over the age of 18. The Company does not permit those under 18 to use the Service.
+
+Your access to and use of the Service is also conditioned on Your acceptance of and compliance with the Privacy Policy of the Company. Our Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your personal information when You use the Application or the Website and tells You about Your privacy rights and how the law protects You. Please read Our Privacy Policy carefully before using Our Service.
+
+## Links to Other Websites
+
+Our Service may contain links to third-party web sites or services that are not owned or controlled by the Company.
+
+The Company has no control over, and assumes no responsibility for, the content, privacy policies, or practices of any third party web sites or services. You further acknowledge and agree that the Company shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with the use of or reliance on any such content, goods or services available on or through any such web sites or services.
+
+We strongly advise You to read the terms and conditions and privacy policies of any third-party web sites or services that You visit.
+
+## Termination
+
+We may terminate or suspend Your access immediately, without prior notice or liability, for any reason whatsoever, including without limitation if You breach these Terms and Conditions.
+
+Upon termination, Your right to use the Service will cease immediately.
+
+## Limitation of Liability
+
+Notwithstanding any damages that You might incur, the entire liability of the Company and any of its suppliers under any provision of this Terms and Your exclusive remedy for all of the foregoing shall be limited to the amount actually paid by You through the Service or 100 USD if You haven’t purchased anything through the Service.
+
+To the maximum extent permitted by applicable law, in no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever (including, but not limited to, damages for loss of profits, loss of data or other information, for business interruption, for personal injury, loss of privacy arising out of or in any way related to the use of or inability to use the Service, third-party software and/or third-party hardware used with the Service, or otherwise in connection with any provision of this Terms), even if the Company or any supplier has been advised of the possibility of such damages and even if the remedy fails of its essential purpose.
+
+Some states do not allow the exclusion of implied warranties or limitation of liability for incidental or consequential damages, which means that some of the above limitations may not apply. In these states, each party’s liability will be limited to the greatest extent permitted by law.
+
+## ”AS IS” and “AS AVAILABLE” Disclaimer
+
+The Service is provided to You “AS IS” and “AS AVAILABLE” and with all faults and defects without warranty of any kind. To the maximum extent permitted under applicable law, the Company, on its own behalf and on behalf of its Affiliates and its and their respective licensors and service providers, expressly disclaims all warranties, whether express, implied, statutory or otherwise, with respect to the Service, including all implied warranties of merchantability, fitness for a particular purpose, title and non-infringement, and warranties that may arise out of course of dealing, course of performance, usage or trade practice. Without limitation to the foregoing, the Company provides no warranty or undertaking, and makes no representation of any kind that the Service will meet Your requirements, achieve any intended results, be compatible or work with any other software, applications, systems or services, operate without interruption, meet any performance or reliability standards or be error free or that any errors or defects can or will be corrected.
+
+Without limiting the foregoing, neither the Company nor any of the company’s provider makes any representation or warranty of any kind, express or implied: (i) as to the operation or availability of the Service, or the information, content, and materials or products included thereon; (ii) that the Service will be uninterrupted or error-free; (iii) as to the accuracy, reliability, or currency of any information or content provided through the Service; or (iv) that the Service, its servers, the content, or e-mails sent from or on behalf of the Company are free of viruses, scripts, trojan horses, worms, malware, timebombs or other harmful components.
+
+Some jurisdictions do not allow the exclusion of certain types of warranties or limitations on applicable statutory rights of a consumer, so some or all of the above exclusions and limitations may not apply to You. But in such a case the exclusions and limitations set forth in this section shall be applied to the greatest extent enforceable under applicable law.
+
+## Governing Law
+
+The laws of the Country, excluding its conflicts of law rules, shall govern this Terms and Your use of the Service. Your use of the Application may also be subject to other local, state, national, or international laws.
+
+## Disputes Resolution
+
+If You have any concern or dispute about the Service, You agree to first try to resolve the dispute informally by contacting the Company.
+
+## For European Union (EU) Users
+
+If You are a European Union consumer, you will benefit from any mandatory provisions of the law of the country in which you are resident in.
+
+## United States Legal Compliance
+
+You represent and warrant that (i) You are not located in a country that is subject to the United States government embargo, or that has been designated by the United States government as a “terrorist supporting” country, and (ii) You are not listed on any United States government list of prohibited or restricted parties.
+
+## Severability and Waiver
+
+### Severability
+
+If any provision of these Terms is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect.
+
+### Waiver
+
+Except as provided herein, the failure to exercise a right or to require performance of an obligation under these Terms shall not effect a party’s ability to exercise such right or require such performance at any time thereafter nor shall the waiver of a breach constitute a waiver of any subsequent breach.
+
+## Translation Interpretation
+
+These Terms and Conditions may have been translated if We have made them available to You on our Service. You agree that the original English text shall prevail in the case of a dispute.
+
+## Changes to These Terms and Conditions
+
+We reserve the right, at Our sole discretion, to modify or replace these Terms at any time. If a revision is material We will make reasonable efforts to provide at least 30 days’ notice prior to any new terms taking effect. What constitutes a material change will be determined at Our sole discretion.
+
+By continuing to access or use Our Service after those revisions become effective, You agree to be bound by the revised terms. If You do not agree to the new terms, in whole or in part, please stop using the website and the Service.
+
+## Contact Us
+
+If you have any questions about these Terms and Conditions, You can contact us:
+
+- By email: [humans@trieve.ai](mailto:humans@trieve.ai)

--- a/src/layouts/shared/LayoutFooter.astro
+++ b/src/layouts/shared/LayoutFooter.astro
@@ -18,8 +18,8 @@ const supportLinks: FooterLink[] = [
 const companyLinks: FooterLink[] = [
   { label: "About", href: "/about" },
   { label: "Admin Dashboard", href: "/admin" },
-  { label: "Privacy Policy", href: "/privacy" },
-  { label: "Terms of Service", href: "/terms" },
+  { label: "Privacy Policy", href: "/legal/privacy-policy" },
+  { label: "Terms of Service", href: "/legal/terms-of-service" },
   { label: "Trust Center", href: "/trust" },
   { label: "GitHub", href: "https://github.com/trieve" },
 ];

--- a/src/lib/keystatic/collections/articles.ts
+++ b/src/lib/keystatic/collections/articles.ts
@@ -1,7 +1,7 @@
 import { collection, fields } from "@keystatic/core";
 
 export const articles = collection({
-  label: "Blog Articles",
+  label: "Blog articles",
   path: "src/content/articles/*/",
   slugField: "title",
   format: {

--- a/src/lib/keystatic/collections/authors.ts
+++ b/src/lib/keystatic/collections/authors.ts
@@ -1,7 +1,7 @@
 import { collection, fields } from "@keystatic/core";
 
 export const authors = collection({
-  label: "Blog Authors",
+  label: "Blog authors",
   path: "src/content/authors/*/",
   slugField: "name",
   columns: ["name", "bio"],

--- a/src/lib/keystatic/collections/legal-pages.ts
+++ b/src/lib/keystatic/collections/legal-pages.ts
@@ -1,0 +1,23 @@
+import { collection, fields } from "@keystatic/core";
+
+import { metaData } from "../shared/metadata";
+import { title } from "../shared/title";
+
+export const legalPages = collection({
+  label: "Legal pages",
+  path: "src/content/legal/*/",
+  format: {
+    data: "yaml",
+    contentField: "content",
+  },
+  slugField: "title",
+  columns: ["title"],
+  schema: {
+    title,
+    metaData,
+    content: fields.markdoc({
+      label: "Content",
+      description: "The content of the page",
+    }),
+  },
+});

--- a/src/lib/keystatic/collections/pages.ts
+++ b/src/lib/keystatic/collections/pages.ts
@@ -1,30 +1,17 @@
-import { collection, fields } from "@keystatic/core";
+import { collection } from "@keystatic/core";
 
 import { metaData } from "../shared/metadata";
 import { pageHeader } from "../shared/page-header";
 import { contentBlocks } from "../shared/content-blocks";
+import { title } from "../shared/title";
 
 export const pages = collection({
-  label: "Pages",
+  label: "Content pages",
   path: "src/content/pages/*/",
   slugField: "title",
   columns: ["title"],
   schema: {
-    title: fields.slug({
-      name: {
-        label: "Page title",
-        description: "The name of the page (may be used in navigation, etc.)",
-        validation: {
-          isRequired: true,
-        },
-      },
-      // Optional slug label overrides
-      slug: {
-        label: "SEO-friendly slug",
-        description:
-          "The unique, URL-friendly slug for the page (don't include slashes in front)",
-      },
-    }),
+    title,
     metaData,
     pageHeader,
     contentBlocks,

--- a/src/lib/keystatic/shared/title.ts
+++ b/src/lib/keystatic/shared/title.ts
@@ -1,0 +1,17 @@
+import { fields } from "@keystatic/core";
+
+export const title = fields.slug({
+  name: {
+    label: "Page title",
+    description: "The name of the page (may be used in navigation, etc.)",
+    validation: {
+      isRequired: true,
+    },
+  },
+  // Optional slug label overrides
+  slug: {
+    label: "SEO-friendly slug",
+    description:
+      "The unique, URL-friendly slug for the page (don't include slashes in front)",
+  },
+});

--- a/src/lib/markdoc/index.ts
+++ b/src/lib/markdoc/index.ts
@@ -1,0 +1,18 @@
+import Markdoc, { type Node } from "@markdoc/markdoc";
+
+type ContentFn = () => Promise<{ node: Node }>;
+
+export async function renderHtml(contentFn: ContentFn): Promise<string | null> {
+  const content = await contentFn();
+  const errors = Markdoc.validate(content.node);
+
+  if (errors.length) {
+    console.error(errors);
+    return null;
+  }
+
+  const transformed = Markdoc.transform(content.node);
+  const html = Markdoc.renderers.html(transformed);
+
+  return html;
+}

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -1,0 +1,38 @@
+---
+import { keystatic } from "@lib/keystatic/client";
+import Layout from "@layouts/Layout.astro";
+import MarkdocRenderer from "@components/shared/MarkdocRenderer.astro";
+
+// Generate paths for all blog posts
+export async function getStaticPaths() {
+  const pages = await keystatic.collections.legalPages.all();
+
+  return pages.map((page) => ({
+    params: { slug: page.slug },
+    props: { page },
+  }));
+}
+
+const { page } = Astro.props;
+const { title, metaData, content } = page.entry;
+
+const pageTitle = metaData.title || title;
+const pageDescription = metaData.description;
+---
+
+<Layout pageTitle={pageTitle} pageDescription={pageDescription}>
+  <div class="container mx-auto px-12">
+    <div
+      class="max-w-none prose prose-lg prose-stone prose-headings:font-serif prose-img:rounded-md prose-img:shadow-md prose-img:p-2 prose-img:bg-white"
+    >
+      <h1
+        class="mt-16 text-4xl lg:text-5xl xl:text-6xl text-stone-800 font-normal font-serif tracking-tighter text-balance max-w-4xl"
+      >
+        {title}
+      </h1>
+      <div class="max-w-4xl">
+        <MarkdocRenderer contentFn={content} />
+      </div>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
Legal pages have bit distict layout that the other pages, they are quite simple and only render Markdown. It doesn't make sense to keep them colocated with the rest of the dynamic pages, hence new collection.

- Define new collection for "Legal Pages"
- Added content for "Terms of Service" and "Privacy Policy" pages
- Updated some of the labels in the admin, improved fields reusability
- Add Astro page templates for rendering legal pages
- Add MarkdocRenderer component to display Markdoc content

Example:
<img width="1223" alt="Screenshot 2025-02-24 at 17 58 49" src="https://github.com/user-attachments/assets/594d3b22-0461-4579-86c8-5372684d2b49" />
