### PR TITLE
Fix build command to output static site build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,13 +6,20 @@ import react from "@astrojs/react";
 import markdoc from "@astrojs/markdoc";
 import sitemap from "@astrojs/sitemap";
 
+const isDev = process.env.NODE_ENV !== "production";
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://trieve.ai/",
   devToolbar: {
     enabled: false,
   },
-  integrations: [react(), markdoc(), keystatic(), sitemap()],
+  integrations: [
+    react(),
+    markdoc(),
+    sitemap(),
+    ...(isDev ? [keystatic()] : []),
+  ],
   vite: {
     resolve: {
       alias: {


### PR DESCRIPTION
Minor fix to the Astro & Keystatic setup, to not include `keystatic()` integration in "production" environment, to enable fully static build.

See https://github.com/Thinkmill/keystatic/discussions/826 for details